### PR TITLE
issue and feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Environment**:
+*(Hint: "Report Kubernetes Extension Issue on Github" command will fill these out for you.)*
+Extension version:
+VSCode version:
+OS: 
+
+**Description**:
+
+**Repro step**:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Use case**
+What are you trying to do that our extension doesn't let you?
+Eg, I want to deploy frequently to manually test my code change.
+Running deploy command every time is annoying.
+
+**Feature**
+What would help?
+Eg, Maybe a continuous deploy command?


### PR DESCRIPTION
Issue template is the same as what `openGithubIssue` command would populate, except we can't fill in version numbers. This template is just here for users who didn't know/want to report from extension.

Feature template doesn't have any user-dependent value. In the future, we'll create a `newFeatureRequest` command that just opens up the template in browser.