### PR TITLE
Fix whitespace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Get run-ready samples, out-of-the-box configuration snippets, support for key Go
 
 <details>
   <summary>Read more</summary>
-  
+
   ### Highlights:
   - Pick your preferred language with Cloud Code’s support for Go, Java, Node.js, Python, .NET Core app development.
   - Get straight to developing with Cloud Code’s simplified authentication workflow that uses your Google Cloud credentials.


### PR DESCRIPTION
Removes the extra whitespace from a line.

Was causing the succeeding header to be rendered as `### Highlights:` in some renderers including the one used on [VS Code's marketplace](https://marketplace.visualstudio.com/items?itemName=GoogleCloudTools.cloudcode).