### PR TITLE
Update README.md to include mitigation steps for xcrun: error: invalid active developer path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*\*\*If you run into problems with managed dependencies failing on MacOS, it may be failing due to a [recent MacOS update](https://developer.apple.com/forums/thread/673827) that can cause the following error `xcrun: error: invalid active developer path`. If you experience this error, please run `xcode-select --install` and restart VSCode.\*\**
+*\*\*MacOS Users: Due to a recent [update to xcrun](https://developer.apple.com/forums/thread/673827), Managed Dependency installation may fail. To fix this, run `xcode-select --install` through the VSCode terminal. If that does not resolve the issue, run `sudo xcode-select --reset`\*\**
 
 # Cloud Code for Visual Studio Code
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*\*\*If you run into problems with managed dependencies failing on MacOS, it may be failing due to a [recent MacOS update](https://developer.apple.com/forums/thread/673827) that can cause the following error `xcrun: error: invalid active developer path`. If you experience this error, please run `xcode-select --install` and restart VSCode.\*\**
+
 # Cloud Code for Visual Studio Code
 
 Cloud Code for VS Code brings the power and convenience of IDEs to cloud-native application development. Cloud Code integrates with Google Cloud services like Google


### PR DESCRIPTION
Recent MacOS update can cause managed dependency installation to fail. https://developer.apple.com/forums/thread/673827

Adding text to the top of the readme instructing users how to mitigate this.