### PR TITLE
Revert "Update README.md to include mitigation steps for xcrun: error: invalid active developer path"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-*\*\*MacOS Users: Due to a recent [update to xcrun](https://developer.apple.com/forums/thread/673827), Managed Dependency installation may fail. To fix this, run `xcode-select --install` through the VSCode terminal. If that does not resolve the issue, run `sudo xcode-select --reset`\*\**
-
 # Cloud Code for Visual Studio Code
 
 Cloud Code for VS Code brings the power and convenience of IDEs to cloud-native application development. Cloud Code integrates with Google Cloud services like Google


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-code-vscode#724